### PR TITLE
Исправлено вертикальное выравнивание для иконки RSS

### DIFF
--- a/screen.css
+++ b/screen.css
@@ -876,11 +876,6 @@ body>nav ul {
     }
 }
 
-.maskImage ul.subscription {
-    position: relative;
-    top: .2em
-}
-
 .maskImage ul.subscription li, .maskImage ul.subscription a {
     border: 0;
     padding: 0


### PR DESCRIPTION
![screenshot_rss_align](https://cloud.githubusercontent.com/assets/819186/21421122/dd84edac-c839-11e6-9799-007f161141a8.png)

Проверил в Google Chrome и в Firefox Nightly, младшие версии Firefox (что странно), как и IE/Edge не поддерживают свойство `mask-image`.